### PR TITLE
Added "vue-template-compiler" to package.json because of build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@vue/cli-plugin-eslint": "^3.0.0-beta.9",
     "@vue/cli-service": "^3.0.0-beta.9",
     "@vue/eslint-config-prettier": "^3.0.0-beta.9",
+    "vue-template-compiler": "^2.5.17",
     "node-sass": "^4.8.3",
     "sass-loader": "^6.0.7"
   },


### PR DESCRIPTION
Ran `npm run dev`.
Got `Error: Cannot find module 'vue-template-compiler/package.json'`

Ran `npm i --save-dev vue-template-compiler`
Script worked